### PR TITLE
Improve CLI Usability and Fix Model Discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Examples:
 spitter modelname http://192.168.0.100:11434
 
 # Push all models to the remote host
-spitter modelname http://192.168.0.100:11434 --all
+spitter http://192.168.0.100:11434 --all
 
 # With custom model directory
 spitter modelname http://192.168.0.100:11434 --model-dir /path/to/custom/models
@@ -53,7 +53,7 @@ spitter modelname http://192.168.0.100:11434 --ollama-cmd "docker exec -it ollam
 spitter modelname http://192.168.0.100:11434 --model-dir /path/to/custom/models --ollama-cmd "docker exec -it ollama ollama"
 
 # Push all models with custom model directory
-spitter modelname http://192.168.0.100:11434 --all --model-dir /path/to/custom/models
+spitter http://192.168.0.100:11434 --all --model-dir /path/to/custom/models
 ```
 
 ### As a Go package
@@ -76,7 +76,6 @@ if err != nil {
 
 // Example 2: Sync all models
 configAll := spitter.SyncConfig{
-    LocalModel:     "modelname", // Still required but will be ignored when AllModels is true
     RemoteServer:   "http://192.168.0.100:11434",
     CustomModelDir: "/path/to/custom/models", // Optional: custom Ollama model directory
     OllamaCommand:  "docker exec ollama ollama", // Optional: custom Ollama command

--- a/cmd/spitter/spitter.go
+++ b/cmd/spitter/spitter.go
@@ -14,18 +14,36 @@ func main() {
 	var allModels bool
 
 	var rootCmd = &cobra.Command{
-		Use:   "spitter [local_model] [remote_server]",
+		Use:   "spitter [local_model] remote_server",
 		Short: "Copy local Ollama models to a remote instance",
-		Long:  `spitter is a tool to copy local Ollama models to a remote instance, skipping already transferred images.`,
-		Args:  cobra.ExactArgs(2),
+		Long:  `spitter is a tool to copy local Ollama models to a remote instance, skipping already transferred images. When using the --all flag, only the remote_server argument should be provided.`,
+		Args: func(cmd *cobra.Command, args []string) error {
+			all, _ := cmd.Flags().GetBool("all")
+			if all {
+				if len(args) != 1 {
+					return fmt.Errorf("requires the remote_server argument when using --all")
+				}
+			} else {
+				if len(args) != 2 {
+					return fmt.Errorf("requires local_model and remote_server arguments")
+				}
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			config := spitter.SyncConfig{
-				LocalModel:     args[0],
-				RemoteServer:   args[1],
 				CustomModelDir: customModelDir,
 				OllamaCommand:  ollamaCommand,
 				AllModels:      allModels,
 			}
+
+			if allModels {
+				config.RemoteServer = args[0]
+			} else {
+				config.LocalModel = args[0]
+				config.RemoteServer = args[1]
+			}
+
 			return spitter.Sync(config)
 		},
 	}

--- a/spitter/spitter.go
+++ b/spitter/spitter.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/http"
 	"net/url"
 	"os"
@@ -36,70 +37,63 @@ type Manifest struct {
 
 // listModels returns a list of all available models in the Ollama models directory
 func listModels(baseDir string) ([]string, error) {
+	manifestsRoot := filepath.Join(baseDir, "manifests")
 	var models []string
 
-	// Check the standard library models
-	libraryDir := filepath.Join(baseDir, "manifests", "registry.ollama.ai", "library")
-	if _, err := os.Stat(libraryDir); err == nil {
-		entries, err := os.ReadDir(libraryDir)
-		if err != nil {
-			return nil, fmt.Errorf("error reading library models directory: %w", err)
-		}
-
-		for _, entry := range entries {
-			if !entry.IsDir() {
-				modelName := entry.Name()
-				// Replace path separator with colon for model name format
-				modelName = strings.Replace(modelName, string(os.PathSeparator), ":", -1)
-				models = append(models, modelName)
-			}
-		}
+	if _, err := os.Stat(manifestsRoot); os.IsNotExist(err) {
+		return models, nil // No manifests directory, so no models.
 	}
 
-	// Check for hub models
-	hubDir := filepath.Join(baseDir, "manifests", "hub")
-	if _, err := os.Stat(hubDir); err == nil {
-		entries, err := os.ReadDir(hubDir)
+	err := filepath.WalkDir(manifestsRoot, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			return nil, fmt.Errorf("error reading hub models directory: %w", err)
+			return err
 		}
 
-		for _, entry := range entries {
-			if !entry.IsDir() {
-				modelName := "hub/" + entry.Name()
-				// Replace path separator with colon for model name format
-				modelName = strings.Replace(modelName, string(os.PathSeparator), ":", -1)
-				models = append(models, modelName)
-			}
+		if d.IsDir() {
+			return nil
 		}
-	}
 
-	// Check for other models in registry.ollama.ai
-	registryDir := filepath.Join(baseDir, "manifests", "registry.ollama.ai")
-	if _, err := os.Stat(registryDir); err == nil {
-		entries, err := os.ReadDir(registryDir)
+		relPath, err := filepath.Rel(manifestsRoot, path)
 		if err != nil {
-			return nil, fmt.Errorf("error reading registry models directory: %w", err)
+			return err
 		}
 
-		for _, entry := range entries {
-			if entry.IsDir() && entry.Name() != "library" {
-				subDir := filepath.Join(registryDir, entry.Name())
-				subEntries, err := os.ReadDir(subDir)
-				if err != nil {
-					continue
-				}
+		parts := strings.Split(relPath, string(os.PathSeparator))
+		if len(parts) < 2 {
+			return nil // Not enough parts for a model name
+		}
 
-				for _, subEntry := range subEntries {
-					if !subEntry.IsDir() {
-						modelName := entry.Name() + "/" + subEntry.Name()
-						// Replace path separator with colon for model name format
-						modelName = strings.Replace(modelName, string(os.PathSeparator), ":", -1)
-						models = append(models, modelName)
-					}
-				}
+		var modelName string
+		// The last part is the tag
+		tag := parts[len(parts)-1]
+		// The parts before the tag form the model path
+		modelPathParts := parts[:len(parts)-1]
+
+		// Handle different repository structures
+		if modelPathParts[0] == "registry.ollama.ai" {
+			// Path: registry.ollama.ai/library/model/version or registry.ollama.ai/namespace/model/version
+			if len(modelPathParts) > 2 && modelPathParts[1] == "library" {
+				// It's a library model, name is just "model"
+				modelName = strings.Join(modelPathParts[2:], "/")
+			} else if len(modelPathParts) > 1 {
+				// It's a namespaced model, name is "namespace/model"
+				modelName = strings.Join(modelPathParts[1:], "/")
 			}
+		} else {
+			// Other registries or hub models. The full path is the model name.
+			// e.g., hub/user/model
+			modelName = strings.Join(modelPathParts, "/")
 		}
+
+		if modelName != "" {
+			models = append(models, fmt.Sprintf("%s:%s", modelName, tag))
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("error walking models directory: %w", err)
 	}
 
 	return models, nil


### PR DESCRIPTION
This PR introduces several improvements to the `spitter` command-line tool, focusing on fixing the model discovery mechanism and making the command-line syntax more intuitive.

### Description

The primary motivation for this PR was to address two key issues:
1.  The `--all` flag was not finding any models to sync due to an incorrect model discovery method.
2.  The command-line syntax required a redundant `local_model` argument when the `--all` flag was used.

These issues made the tool difficult to use for its core purpose of syncing all models.

### Changes Included

-   **`fix(models)`: Correctly list all Ollama models**
    -   The `listModels` function has been refactored to recursively scan the Ollama manifests directory.
    -   This change ensures that all locally stored models are correctly found when using the `--all` flag.

-   **`refactor(cli)`: Improve argument handling for `--all` flag**
    -   The CLI argument parsing logic has been updated.
    -   `spitter` no longer requires the `local_model` argument when `--all` is specified, making the syntax more logical.

-   **`docs`: Update README with new CLI syntax**
    -   The usage examples in the `README.md` file have been updated to reflect the new, corrected command-line syntax.
    -   The Go package usage example was also corrected.
